### PR TITLE
Quickstart url print in docs

### DIFF
--- a/docs/content/quickstart.rst
+++ b/docs/content/quickstart.rst
@@ -188,7 +188,7 @@ and share the project on `steno3d.com <https://steno3d.com>`_.
 
 .. code:: python
 
-    >> print(proj.url)
+    >> print(my_proj.url)
 
 
 .. _try_steno3d:


### PR DESCRIPTION
Found this while playing with your package. In the docs, at the the end of the quick start there was a ```print(proj.url)```, but it should be ```print(my_proj.url)``` to be consistent with the rest of the example and the Jupyter notebook. Not sure if you want this against master, but wanted to point out the error.