### PR TITLE
Fix graph rendering.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 	pylint --output-format=html steno3d > pylint.html
 
 graphs:
-	pyreverse -my -A -o pdf -p steno3d steno3d/**.py steno3d/**/**.py steno3d/**/**/**.py
+	pyreverse -my -A -o pdf -p steno3dpy steno3d/**.py steno3d/**/**.py
 
 tests:
 	nosetests --logging-level=INFO


### PR DESCRIPTION
This fixes the graph rendering (and labels the PDFs based on the name `steno3dpy`, rather than `steno3d`).