### PR TITLE
Allow no data to be specified on categories using -1

### DIFF
--- a/steno3d/client.py
+++ b/steno3d/client.py
@@ -295,7 +295,7 @@ class _Comms(object):
             resp = requests.post(
                 self.base_url + 'api/client/steno3dpy',
                 dict(version=__version__),
-                timeout=(10, 60),
+                timeout=60,
             )
         except requests.ConnectionError:
             if verbose:
@@ -353,7 +353,7 @@ class _Comms(object):
                 self.base_url + 'api/me',
                 headers={'sshKey': devel_key,
                          'client': 'steno3dpy:{}'.format(__version__)},
-                timeout=(10, 60),
+                timeout=60,
             )
         except requests.ConnectionError:
             if verbose:
@@ -430,7 +430,7 @@ class _Comms(object):
             files=filedict,
             headers=headers,
             cookies=Comms._cookies,
-            timeout=(10, 60),
+            timeout=60,
         )
         if req.status_code < 210:
             Comms._cookies.update(req.cookies)

--- a/steno3d/props.py
+++ b/steno3d/props.py
@@ -76,7 +76,7 @@ class HasSteno3DProps(properties.HasProperties):
 
 
 def image_download(url, **kwargs):
-    im_resp = get(url, timeout=(10, 60))
+    im_resp = get(url, timeout=60)
     if im_resp.status_code != 200:
         raise IOError('Failed to download image.')
     output = BytesIO()
@@ -118,7 +118,7 @@ class array_download(object):
         self.dtype = dtype
 
     def __call__(self, url, **kwargs):
-        arr_resp = get(url, timeout=(10, 60))
+        arr_resp = get(url, timeout=60)
         if arr_resp.status_code != 200:
             raise IOError('Failed to download array.')
         data_file = NamedTemporaryFile()


### PR DESCRIPTION
Previously, `DataCategory` had no way to specify No Data, unlike `DataArray`, where you can specify `np.nan`. Since `DataCategory` array (indices) must be integers, `np.nan` cannot be used.

This PR allows No Data to be specified on `DataCategory` using -1. Behind the scenes, on serialization, the indices are converted to floats and `-1` is replaced with `np.nan`. This allows correct visualization.

For example:
```python
categories=['a', 'b', 'c']
colors=['red', 'green', 'blue']

indices=[-1, -1, 0, 0, 1, 1, 2, 2]

steno3d.Volume(
    project=steno3d.Project(),
    mesh={
        'h1': [1, 1],
        'h2': [1, 1],
        'h3': [1, 1],
    },
    data=[
        {
            'location': 'CC',
            'data': steno3d.DataCategory(
                array=indices,
                categories=categories,
                colormap=colors,
            )
        }
    ],
).project[0].upload()
```
results in:
<img width="806" alt="screen shot 2017-05-26 at 11 35 26 pm" src="https://cloud.githubusercontent.com/assets/9453731/26518350/1a19a40e-426c-11e7-805f-d1a84e23a3b2.png">
